### PR TITLE
feat: Addition of ARM Template Detection

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -238,7 +238,21 @@ func TestBreakdownConfigFile(t *testing.T) {
 		},
 	)
 }
-
+func TestBreakdownArmTemplateConfigFile(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--config-file", path.Join(dir, "infracost.yml"),
+		},
+		&GoldenFileOptions{
+			IsJSON: true,
+		},
+	)
+}
 func TestBreakdownConfigFileWithUsageFile(t *testing.T) {
 	testName := testutil.CalcGoldenFileTestdataDirName()
 	dir := path.Join("./testdata", testName)

--- a/cmd/infracost/testdata/breakdown_arm_template_config_file/breakdown_arm_template_config_file.golden
+++ b/cmd/infracost/testdata/breakdown_arm_template_config_file/breakdown_arm_template_config_file.golden
@@ -1,0 +1,23 @@
+Project: standard_disk
+
+ Name                                     Monthly Qty  Unit                      Monthly Cost   
+                                                                                                
+ Microsoft.Compute/disks/standard                                                               
+ ├─ Storage (S40, LRS)                              1  months                          $85.60   
+ └─ Disk operations                Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                
+ OVERALL TOTAL                                                                        $85.60 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+No cloud resources were detected
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ standard_disk                                      ┃           $86 ┃           - ┃        $86 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_arm_template_config_file/infracost.yml
+++ b/cmd/infracost/testdata/breakdown_arm_template_config_file/infracost.yml
@@ -1,0 +1,4 @@
+version: 0.1
+projects:
+ - path: ./testdata/breakdown_arm_template_config_file/standard_disk.json
+   name : standard_disk

--- a/cmd/infracost/testdata/breakdown_arm_template_config_file/standard_disk.json
+++ b/cmd/infracost/testdata/breakdown_arm_template_config_file/standard_disk.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+      {
+        "type": "Microsoft.Compute/disks",
+        "apiVersion": "2023-10-02",
+        "name": "standard",
+        "location": "francecentral",
+        "properties": {
+          "creationData": {
+            "createOption": "Empty"
+          },
+          "diskSizeGB": 2000,
+          "diskIOPSReadWrite": 4000,
+          "diskMBpsReadWrite": 20
+        },
+        "sku": {
+          "name": "Standard_LRS"
+        }
+      }
+    ]
+  }

--- a/examples/arm/managed_disk/config.yml
+++ b/examples/arm/managed_disk/config.yml
@@ -1,0 +1,4 @@
+version: 0.1
+projects:
+ - path: ./examples/arm/managed_disk//standard_disk.json
+   name : standard_disk

--- a/examples/arm/managed_disk/standard_disk.json
+++ b/examples/arm/managed_disk/standard_disk.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+      {
+        "type": "Microsoft.Compute/disks",
+        "apiVersion": "2023-10-02",
+        "name": "standard",
+        "location": "francecentral",
+        "properties": {
+          "creationData": {
+            "createOption": "Empty"
+          },
+          "diskSizeGB": 2000,
+          "diskIOPSReadWrite": 4000,
+          "diskMBpsReadWrite": 20
+        },
+        "sku": {
+          "name": "Standard_LRS"
+        }
+      }
+    ]
+  }

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl"
 	"github.com/infracost/infracost/internal/logging"
+	"github.com/infracost/infracost/internal/providers/arm"
 	"github.com/infracost/infracost/internal/providers/cloudformation"
 	"github.com/infracost/infracost/internal/providers/terraform"
 	"github.com/infracost/infracost/internal/schema"
@@ -51,6 +53,8 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		return &DetectionOutput{Providers: []schema.Provider{terraform.NewStateJSONProvider(projectContext, includePastResources)}, RootModules: 1}, nil
 	case ProjectTypeCloudFormation:
 		return &DetectionOutput{Providers: []schema.Provider{cloudformation.NewTemplateProvider(projectContext, includePastResources)}, RootModules: 1}, nil
+	case ProjectTypeARMTemplate:
+		return &DetectionOutput{Providers: []schema.Provider{arm.NewTemplateProvider(projectContext, includePastResources, project.Path)}}, nil
 	}
 
 	pathOverrides := make([]hcl.PathOverrideConfig, len(ctx.Config.Autodetect.PathOverrides))
@@ -201,10 +205,12 @@ var (
 	ProjectTypeTerragruntCLI       ProjectType = "terragrunt_cli"
 	ProjectTypeTerraformStateJSON  ProjectType = "terraform_state_json"
 	ProjectTypeCloudFormation      ProjectType = "cloudformation"
+	ProjectTypeARMTemplate         ProjectType = "arm_template"
 	ProjectTypeAutodetect          ProjectType = "autodetect"
 )
 
 func DetectProjectType(path string, forceCLI bool) ProjectType {
+
 	if isCloudFormationTemplate(path) {
 		return ProjectTypeCloudFormation
 	}
@@ -220,6 +226,9 @@ func DetectProjectType(path string, forceCLI bool) ProjectType {
 	if isTerraformPlan(path) {
 		return ProjectTypeTerraformPlanBinary
 	}
+	if IsARMTemplate(path) {
+		return ProjectTypeARMTemplate
+	}
 
 	if forceCLI {
 		if isTerragruntNestedDir(path, 5) {
@@ -230,6 +239,21 @@ func DetectProjectType(path string, forceCLI bool) ProjectType {
 	}
 
 	return ProjectTypeAutodetect
+}
+
+func IsARMTemplate(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("Failed to read file: %v", err)
+	}
+
+	//Store the file content in the content struct
+	var content arm.FileContent
+	if err = json.Unmarshal(data, &content); err != nil {
+		log.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+	//If it is not an ARM template, return
+	return arm.IsARMTemplate(content)
 }
 
 func isTerraformPlanJSON(path string) bool {


### PR DESCRIPTION
- Addition of ARM Template detection in detect.go in order to use Infracost on ARM Templates. However, this only works with config files for the moment.
- Addition of a test in the breadkdown_test.go file in order to test if the cost estimation through the breakdown command is working