### PR TITLE
Adding support for the path flag

### DIFF
--- a/cmd/infracost/breakdown.go
+++ b/cmd/infracost/breakdown.go
@@ -50,6 +50,7 @@ func breakdownCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().Bool("terraform-use-state", false, "Use Terraform state instead of generating a plan. Applicable with --terraform-force-cli")
 	newEnumFlag(cmd, "format", "table", "Output format", []string{"json", "table", "html"})
 	cmd.Flags().StringSlice("fields", []string{"monthlyQuantity", "unit", "monthlyCost"}, "Comma separated list of output fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.\nSupported by table and html output formats")
+	cmd.Flags().String("iac", "terraform", "The name of the Infrastructure as Code tool you are using: terraform, cloudformation, arm, etc...")
 
 	// This is deprecated and will show a warning if used without --terraform-force-cli
 	_ = cmd.Flags().MarkHidden("terraform-use-state")

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -285,6 +285,13 @@ func TestBreakdownMultiProjectSkipPathsRootLevel(t *testing.T) {
 		}, nil,
 	)
 }
+
+func TestBreakdownArmMultiProject(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", dir, "--iac", "arm"}, nil)
+}
+
 func TestBreakdownArmDirectory(t *testing.T) {
 	testName := testutil.CalcGoldenFileTestdataDirName()
 	dir := path.Join("./testdata", testName)

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -285,6 +285,11 @@ func TestBreakdownMultiProjectSkipPathsRootLevel(t *testing.T) {
 		}, nil,
 	)
 }
+func TestBreakdownArmDirectory(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", dir, "--iac", "arm"}, nil)
+}
 
 func TestBreakdownArmTemplateConfigFile(t *testing.T) {
 	testName := testutil.CalcGoldenFileTestdataDirName()

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -822,6 +822,7 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 		}
 	}
 
+	cfg.IaC, _ = cmd.Flags().GetString("iac")
 	cfg.NoCache, _ = cmd.Flags().GetBool("no-cache")
 	cfg.Format, _ = cmd.Flags().GetString("format")
 	cfg.ShowSkipped, _ = cmd.Flags().GetBool("show-skipped")

--- a/cmd/infracost/testdata/breakdown_arm_directory/breakdown_arm_directory.golden
+++ b/cmd/infracost/testdata/breakdown_arm_directory/breakdown_arm_directory.golden
@@ -1,0 +1,67 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_arm_directory/linux_virtual_machine_test.json
+
+ Name                                                                       Monthly Qty  Unit                      Monthly Cost   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_a2_v2_custom_disk                                                               
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                           730  hours                           $65.92   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (E30, LRS)                                                             1  months                          $76.80   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.002 per 10k operations     
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_f2_lowercase                                                                    
+ ├─ Instance usage (Linux, pay as you go, standard_f2)                              730  hours                           $72.27   
+ └─ os_disk                                                                                                                       
+    └─ Storage (P4, LRS)                                                              1  months                           $5.28   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_f2_premium_disk                                                                 
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                              730  hours                           $72.27   
+ └─ os_disk                                                                                                                       
+    └─ Storage (P4, LRS)                                                              1  months                           $5.28   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_a2_ultra_enabled                                                                
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                           730  hours                           $65.92   
+ ├─ Ultra disk reservation (if unattached)                           Monthly cost depends on usage: $4.38 per vCPU                
+ └─ os_disk                                                                                                                       
+    ├─ Storage (E4, LRS)                                                              1  months                           $2.40   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.002 per 10k operations     
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_a2                                                                                 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                                 730  hours                           $57.67   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1                                                                                 
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1_lowercase                                                                       
+ ├─ Instance usage (Linux, pay as you go, standard_b1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1_withMonthlyHours                                                                
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ OVERALL TOTAL                                                                                                         $452.73 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+8 cloud resources were detected:
+∙ 8 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...inux_virtual_machine_test.json ┃          $453 ┃           - ┃       $453 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_arm_directory/linux_virtual_machine_test.json
+++ b/cmd/infracost/testdata/breakdown_arm_directory/linux_virtual_machine_test.json
@@ -1,0 +1,321 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+      "_generator": {
+        "name": "example",
+        "version": "0.27.1.19265",
+        "templateHash": "4270386830956032562"
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_B1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1_lowercase",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "standard_b1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_a2",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Basic_A2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_a2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_f2_premium_disk",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_F2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_f2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_f2_lowercase",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "standard_f2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_f2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_a2_v2_custom_disk",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_A2_v2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "StandardSSD_LRS",
+                "caching": "ReadWrite"
+              },
+              "diskSizeGB": 1000
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_a2_v2_custom_disk",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_a2_ultra_enabled",
+        "location": "eastus",
+        "properties": {
+          "additionalCapabilities": {
+          "ultraSSDEnabled": true
+          },
+          "hardwareProfile": {
+            "vmSize": "Standard_A2_v2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "StandardSSD_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_a2_ultra_enabled",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1_withMonthlyHours",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_B1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }

--- a/cmd/infracost/testdata/breakdown_arm_multi_project/breakdown_arm_multi_project.golden
+++ b/cmd/infracost/testdata/breakdown_arm_multi_project/breakdown_arm_multi_project.golden
@@ -1,0 +1,148 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_arm_multi_project/first_project/linux_virtual_machine_test.json
+
+ Name                                                                       Monthly Qty  Unit                      Monthly Cost   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_a2_v2_custom_disk                                                               
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                           730  hours                           $65.92   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (E30, LRS)                                                             1  months                          $76.80   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.002 per 10k operations     
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_f2_lowercase                                                                    
+ ├─ Instance usage (Linux, pay as you go, standard_f2)                              730  hours                           $72.27   
+ └─ os_disk                                                                                                                       
+    └─ Storage (P4, LRS)                                                              1  months                           $5.28   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_f2_premium_disk                                                                 
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                              730  hours                           $72.27   
+ └─ os_disk                                                                                                                       
+    └─ Storage (P4, LRS)                                                              1  months                           $5.28   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_a2_ultra_enabled                                                                
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                           730  hours                           $65.92   
+ ├─ Ultra disk reservation (if unattached)                           Monthly cost depends on usage: $4.38 per vCPU                
+ └─ os_disk                                                                                                                       
+    ├─ Storage (E4, LRS)                                                              1  months                           $2.40   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.002 per 10k operations     
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_a2                                                                                 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                                 730  hours                           $57.67   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1                                                                                 
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1_lowercase                                                                       
+ ├─ Instance usage (Linux, pay as you go, standard_b1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1_withMonthlyHours                                                                
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Project total                                                                                                          $452.73   
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_arm_multi_project/first_project/managed_disk_test.json
+
+ Name                                            Monthly Qty  Unit                      Monthly Cost   
+                                                                                                       
+ Microsoft.Compute/disks/ultra                                                                         
+ ├─ Storage (ultra, 2048 GiB)                          2,048  GiB                            $245.19   
+ ├─ Provisioned IOPS                                   4,000  IOPS                           $198.56   
+ └─ Throughput                                            20  MB/s                             $6.99   
+                                                                                                       
+ Microsoft.Compute/disks/custom_size_ssd                                                               
+ ├─ Storage (E30, LRS)                                     1  months                          $76.80   
+ └─ Disk operations                       Monthly cost depends on usage: $0.002 per 10k operations     
+                                                                                                       
+ Microsoft.Compute/disks/premium                                                                       
+ └─ Storage (P4, LRS)                                      1  months                           $5.28   
+                                                                                                       
+ Microsoft.Compute/disks/standard                                                                      
+ ├─ Storage (S4, LRS)                                      1  months                           $1.54   
+ └─ Disk operations                       Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                       
+ Project total                                                                               $534.36   
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_arm_multi_project/second_project/linux_virtual_machine_test.json
+
+ Name                                                                       Monthly Qty  Unit                      Monthly Cost   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_a2_v2_custom_disk                                                               
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                           730  hours                           $65.92   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (E30, LRS)                                                             1  months                          $76.80   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.002 per 10k operations     
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_f2_lowercase                                                                    
+ ├─ Instance usage (Linux, pay as you go, standard_f2)                              730  hours                           $72.27   
+ └─ os_disk                                                                                                                       
+    └─ Storage (P4, LRS)                                                              1  months                           $5.28   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_f2_premium_disk                                                                 
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                              730  hours                           $72.27   
+ └─ os_disk                                                                                                                       
+    └─ Storage (P4, LRS)                                                              1  months                           $5.28   
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/standard_a2_ultra_enabled                                                                
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                           730  hours                           $65.92   
+ ├─ Ultra disk reservation (if unattached)                           Monthly cost depends on usage: $4.38 per vCPU                
+ └─ os_disk                                                                                                                       
+    ├─ Storage (E4, LRS)                                                              1  months                           $2.40   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.002 per 10k operations     
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_a2                                                                                 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                                 730  hours                           $57.67   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1                                                                                 
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1_lowercase                                                                       
+ ├─ Instance usage (Linux, pay as you go, standard_b1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Microsoft.Compute/virtualMachines/Linux/basic_b1_withMonthlyHours                                                                
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                             730  hours                            $7.59   
+ └─ os_disk                                                                                                                       
+    ├─ Storage (S4, LRS)                                                              1  months                           $1.54   
+    └─ Disk operations                                               Monthly cost depends on usage: $0.0005 per 10k operations    
+                                                                                                                                  
+ Project total                                                                                                          $452.73   
+
+ OVERALL TOTAL                                                                                                       $1,439.81 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+20 cloud resources were detected:
+∙ 20 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...inux_virtual_machine_test.json ┃          $453 ┃           - ┃       $453 ┃
+┃ infracost/infracost/cmd/infraco...project/managed_disk_test.json ┃          $534 ┃           - ┃       $534 ┃
+┃ infracost/infracost/cmd/infraco...inux_virtual_machine_test.json ┃          $453 ┃           - ┃       $453 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_arm_multi_project/first_project/linux_virtual_machine_test.json
+++ b/cmd/infracost/testdata/breakdown_arm_multi_project/first_project/linux_virtual_machine_test.json
@@ -1,0 +1,321 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+      "_generator": {
+        "name": "example",
+        "version": "0.27.1.19265",
+        "templateHash": "4270386830956032562"
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_B1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1_lowercase",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "standard_b1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_a2",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Basic_A2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_a2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_f2_premium_disk",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_F2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_f2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_f2_lowercase",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "standard_f2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_f2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_a2_v2_custom_disk",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_A2_v2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "StandardSSD_LRS",
+                "caching": "ReadWrite"
+              },
+              "diskSizeGB": 1000
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_a2_v2_custom_disk",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_a2_ultra_enabled",
+        "location": "eastus",
+        "properties": {
+          "additionalCapabilities": {
+          "ultraSSDEnabled": true
+          },
+          "hardwareProfile": {
+            "vmSize": "Standard_A2_v2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "StandardSSD_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_a2_ultra_enabled",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1_withMonthlyHours",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_B1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }

--- a/cmd/infracost/testdata/breakdown_arm_multi_project/first_project/managed_disk_test.json
+++ b/cmd/infracost/testdata/breakdown_arm_multi_project/first_project/managed_disk_test.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+      "_generator": {
+        "name": "example",
+        "version": "0.26.54.24096",
+        "templateHash": "7729680081436334184"
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Compute/disks",
+        "apiVersion": "2023-10-02",
+        "name": "standard",
+        "location": "eastus",
+        "properties": {
+          "creationData": {
+            "createOption": "Empty"
+          }
+        },
+        "sku": {
+          "name": "Standard_LRS"
+        }
+      },
+      {
+        "type": "Microsoft.Compute/disks",
+        "apiVersion": "2023-10-02",
+        "name": "premium",
+        "location": "eastus",
+        "properties": {
+          "creationData": {
+            "createOption": "Empty"
+          }
+        },
+        "sku": {
+          "name": "Premium_LRS"
+        }
+      },
+      {
+        "type": "Microsoft.Compute/disks",
+        "apiVersion": "2023-10-02",
+        "name": "custom_size_ssd",
+        "location": "eastus",
+        "properties": {
+          "creationData": {
+            "createOption": "Empty"
+          },
+          "diskSizeGB": 1000
+        },
+        "sku": {
+          "name": "StandardSSD_LRS"
+        }
+      },
+      {
+        "type": "Microsoft.Compute/disks",
+        "apiVersion": "2023-10-02",
+        "name": "ultra",
+        "location": "eastus",
+        "properties": {
+          "creationData": {
+            "createOption": "Empty"
+          },
+          "diskSizeGB": 2000,
+          "diskIOPSReadWrite": 4000,
+          "diskMBpsReadWrite": 20
+        },
+        "sku": {
+          "name": "UltraSSD_LRS"
+        }
+      }
+    ]
+  }

--- a/cmd/infracost/testdata/breakdown_arm_multi_project/second_project/linux_virtual_machine_test.json
+++ b/cmd/infracost/testdata/breakdown_arm_multi_project/second_project/linux_virtual_machine_test.json
@@ -1,0 +1,321 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+      "_generator": {
+        "name": "example",
+        "version": "0.27.1.19265",
+        "templateHash": "4270386830956032562"
+      }
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_B1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1_lowercase",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "standard_b1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_a2",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Basic_A2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_a2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_f2_premium_disk",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_F2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_f2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_f2_lowercase",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "standard_f2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Premium_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_f2",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_a2_v2_custom_disk",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_A2_v2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "StandardSSD_LRS",
+                "caching": "ReadWrite"
+              },
+              "diskSizeGB": 1000
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_a2_v2_custom_disk",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "standard_a2_ultra_enabled",
+        "location": "eastus",
+        "properties": {
+          "additionalCapabilities": {
+          "ultraSSDEnabled": true
+          },
+          "hardwareProfile": {
+            "vmSize": "Standard_A2_v2"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "StandardSSD_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "standard_a2_ultra_enabled",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Compute/virtualMachines",
+        "apiVersion": "2023-09-01",
+        "name": "basic_b1_withMonthlyHours",
+        "location": "eastus",
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "Standard_B1s"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "UbuntuServer",
+              "sku": "16.04-LTSr",
+              "version": "latest"
+            },
+            "osDisk": {
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS",
+                "caching": "ReadWrite"
+              }
+            }
+          },
+          "osProfile": {
+            "computerName": "basic_b1",
+            "adminUsername": "fakeuser",
+            "adminPassword": "Password1234!"
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic')]"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -181,6 +181,8 @@ type Config struct {
 
 	SkipErrLine bool
 
+	IaC string
+
 	// for testing
 	EventsDisabled       bool
 	logWriter            io.Writer


### PR DESCRIPTION
With these changes, we can pass the ARM directory path to infracost, we don't have to specifically specify the path of the file itself. It can also analyze multiple ARM files within the directory and its subdirectories.