### PR TITLE
feat: adding support for bicep modules

### DIFF
--- a/internal/providers/arm/parser.go
+++ b/internal/providers/arm/parser.go
@@ -107,6 +107,14 @@ func (p *Parser) parseResourceData(data *gjson.Result) (map[string]*schema.Resou
 	resources := make(map[string]*schema.ResourceData)
 	for _, res := range data.Array() {
 		t := res.Get("type").String()
+		if t == "Microsoft.Resources/deployments" {
+			d := res.Get("properties").Get("template").Get("resources")
+			r, _ := p.parseResourceData(&d)
+			for k, v := range r {
+				resources[k] = v
+			}
+			continue
+		}
 		if t == "Microsoft.Compute/virtualMachines" {
 			// There is no official naming for Linux or Windows virtual machines, so we need to modify the resource name to obtain the resource from the registry
 			GetOSResourceType(&t, &res)


### PR DESCRIPTION
When we convert a Bicep project into an ARM template, a module is represented by a resource type Microsoft.Resources/deployments that encapsulates all the resources that were defined inside the module. This PR is adding support for modules, which means with we're capable of extracting the resources inside Microsoft.Resources/deployments.